### PR TITLE
Add optional Authorization http header

### DIFF
--- a/app/scripts/bananode-api.js
+++ b/app/scripts/bananode-api.js
@@ -14,11 +14,17 @@
 
   const LOG_GET_GENERATED_WORK = false;
 
-  /*set as authorization string, should set if node wants api key*/
   let auth;
 
-  const setAuth = (auth_string) => {
-    auth = auth_string;
+  /**
+ * Sets an authorization string (http 'Authorization' header), useful if node requires api key.
+ *
+ * @memberof BananodeApi
+ * @param {string} authString api key as a string\
+ * @return {undefined} returns nothing.
+ */
+  const setAuth = (authString) => {
+    auth = authString;
   }
 
   const sendRequest = async (formData) => {

--- a/dist/bananocoin-bananojs.js
+++ b/dist/bananocoin-bananojs.js
@@ -1,5 +1,5 @@
 //bananocoin-bananojs.js
-//version 2.4.19
+//version 2.4.20
 //license MIT
 const require = (modname) => {
   if (typeof BigInt === 'undefined') {
@@ -2116,11 +2116,17 @@ window.bananocoin.bananojs.https.request = (requestOptions, requestWriterCallbac
 
   const LOG_GET_GENERATED_WORK = false;
 
-  /*set as authorization string, should set if node wants api key*/
   let auth;
 
-  const setAuth = (auth_string) => {
-    auth = auth_string;
+  /**
+ * Sets an authorization string (http 'Authorization' header), useful if node requires api key.
+ *
+ * @memberof BananodeApi
+ * @param {string} authString api key as a string\
+ * @return {undefined} returns nothing.
+ */
+  const setAuth = (authString) => {
+    auth = authString;
   }
 
   const sendRequest = async (formData) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bananocoin/bananojs",
-  "version": "2.4.19",
+  "version": "2.4.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bananocoin/bananojs",
-  "version": "2.4.19",
+  "version": "2.4.20",
   "module": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Many nodes have an option or require api keys, so I think it would be a good idea for bananojs to have an option to set one. The function to do so would be `bananojs.bananodeApi.setAuth(auth_string)`. 