### PR TITLE
Correct docs (count in getAccountHistory should be a number)

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -792,7 +792,7 @@ Calls [https://docs.nano.org/commands/rpc-protocol/#account_history](https://doc
 | Param | Type | Description |
 | --- | --- | --- |
 | account | <code>string</code> | the account to use. |
-| count | <code>string</code> | the count to use (use -1 for all). |
+| count | <code>number</code> | the count to use (use -1 for all). |
 | head | <code>string</code> | the head to start at (optional). |
 | raw | <code>string</code> | if true, return raw history (optional). |
 


### PR DESCRIPTION
BananoJS' docs say that `count` should be a string, however it errors as it _should_ be a number.