### PR TITLE
Add message signing and verification

### DIFF
--- a/app/scripts/banano-util.js
+++ b/app/scripts/banano-util.js
@@ -503,6 +503,34 @@
     return uint4;
   };
 
+  const utf8ToBytes = (utf8) => {
+    let bytes = new Uint8Array(utf8.length);
+    for (let i = 0; i < utf8.length; i++) {
+      let code = utf8.charCodeAt(i);
+      if (code > 0xff) {
+        throw Error("Non utf-8 character found");
+      }
+      bytes[i] = code;
+    }
+    return bytes;
+  }
+
+  const signMessage = (privateKey, message) => {
+    const messageBytes = utf8ToBytes(message);
+    const privateKeyBytes = hexToBytes(privateKey);
+    const signed = nacl.sign.detached(messageBytes, privateKeyBytes);
+    const signature = bytesToHex(signed);
+    return signature;
+  }
+
+  const verifyMessage = (publicKey, message, signature) => {
+    const messageBytes = utf8ToBytes(message);
+    const publicKeyBytes = hexToBytes(publicKey);
+    const signatureBytes = hexToBytes(signature);
+    const verifies = nacl.sign.detached.verify(messageBytes, signatureBytes, publicKeyBytes);
+    return verifies;
+  }
+
   const signHash = (privateKey, hash) => {
     //    console.log( `sign ${JSON.stringify( block )}` );
     const hashBytes = hexToBytes(hash);
@@ -1364,6 +1392,9 @@
     exports.getPrivateKey = getPrivateKey;
     exports.hash = hash;
     exports.sign = sign;
+    exports.utf8ToBytes = utf8ToBytes;
+    exports.signMessage = signMessage;
+    exports.verifyMessage = verifyMessage;
     exports.signHash = signHash;
     exports.verify = verify;
     exports.getAccountPublicKey = getAccountPublicKey;

--- a/dist/bananocoin-bananojs.js
+++ b/dist/bananocoin-bananojs.js
@@ -3291,6 +3291,34 @@ window.bananocoin.bananojs.https.request = (
     return uint4;
   };
 
+  const utf8ToBytes = (utf8) => {
+    let bytes = new Uint8Array(utf8.length);
+    for (let i = 0; i < utf8.length; i++) {
+      let code = utf8.charCodeAt(i);
+      if (code > 0xff) {
+        throw Error("Non utf-8 character found");
+      }
+      bytes[i] = code;
+    }
+    return bytes;
+  }
+
+  const signMessage = (privateKey, message) => {
+    const messageBytes = utf8ToBytes(message);
+    const privateKeyBytes = hexToBytes(privateKey);
+    const signed = nacl.sign.detached(messageBytes, privateKeyBytes);
+    const signature = bytesToHex(signed);
+    return signature;
+  }
+
+  const verifyMessage = (publicKey, message, signature) => {
+    const messageBytes = utf8ToBytes(message);
+    const publicKeyBytes = hexToBytes(publicKey);
+    const signatureBytes = hexToBytes(signature);
+    const verifies = nacl.sign.detached.verify(messageBytes, signatureBytes, publicKeyBytes);
+    return verifies;
+  }
+
   const signHash = (privateKey, hash) => {
     //    console.log( `sign ${JSON.stringify( block )}` );
     const hashBytes = hexToBytes(hash);
@@ -4152,6 +4180,9 @@ window.bananocoin.bananojs.https.request = (
     exports.getPrivateKey = getPrivateKey;
     exports.hash = hash;
     exports.sign = sign;
+    exports.utf8ToBytes = utf8ToBytes;
+    exports.signMessage = signMessage;
+    exports.verifyMessage = verifyMessage;
     exports.signHash = signHash;
     exports.verify = verify;
     exports.getAccountPublicKey = getAccountPublicKey;
@@ -6229,6 +6260,31 @@ window.bananocoin.bananojs.https.request = (
   };
 
   /**
+   * signs a utf-8 message with private key.
+   *
+   * @memberof BananoUtil
+   * @param {string} privateKey the private key to use to sign.
+   * @param {string} message the utf-8 message to sign.
+   * @return {string} the message's hash.
+   */
+  const signMessage = (privateKey, message) => {
+    return bananoUtil.signMessage(privateKey, message);
+  };
+
+  /**
+   * verifies a utf-8 message with public key.
+   *
+   * @memberof BananoUtil
+   * @param {string} publicKey the public key to use to sign.
+   * @param {string} message the utf-8 message to verify.
+   * @param {string} signature hex of signature.
+   * @return {string} the message's hash.
+   */
+  const verifyMessage = (publicKey, message, signature) => {
+    return bananoUtil.verifyMessage(publicKey, message, signature);
+  }
+
+  /**
    * signs a hash.
    *
    * @memberof BananoUtil
@@ -6932,6 +6988,8 @@ window.bananocoin.bananojs.https.request = (
       changeBananoRepresentativeForSeed;
     exports.changeNanoRepresentativeForSeed = changeNanoRepresentativeForSeed;
     exports.getSignature = getSignature;
+    exports.signMessage = signMessage;
+    exports.verifyMessage = verifyMessage;
     exports.signHash = signHash;
     exports.verify = verify;
     exports.getBytesFromHex = getBytesFromHex;

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -448,6 +448,8 @@ checks if a camo account is valid.
     * [.openBananoAccountFromSeed(seed, seedIx, representative, pendingBlockHash, pendingValueRaw)](#BananoUtil.openBananoAccountFromSeed) ⇒ <code>Promise.&lt;string&gt;</code>
     * [.openNanoAccountFromSeed(seed, seedIx, representative, pendingBlockHash, pendingValueRaw)](#BananoUtil.openNanoAccountFromSeed) ⇒ <code>Promise.&lt;string&gt;</code>
     * [.getBlockHash(block)](#BananoUtil.getBlockHash) ⇒ <code>string</code>
+    * [.signMessage(privateKey, message)](#BananoUtil.signMessage) ⇒ <code>string</code>
+    * [.verifyMessage(publicKey, message, signature)](#BananoUtil.verifyMessage) ⇒ <code>string</code>
     * [.signHash(privateKey, hash)](#BananoUtil.signHash) ⇒ <code>string</code>
     * [.verify(hash, signature, publicKey)](#BananoUtil.verify) ⇒ <code>string</code>
     * [.getSignature(privateKey, block)](#BananoUtil.getSignature) ⇒ <code>string</code>
@@ -700,6 +702,33 @@ Get the hash for a given block.
 | Param | Type | Description |
 | --- | --- | --- |
 | block | <code>string</code> | the seed to use to find the account. |
+
+<a name="BananoUtil.signMessage"></a>
+
+### BananoUtil.signMessage(privateKey, message) ⇒ <code>string</code>
+signs a utf-8 message with private key.
+
+**Kind**: static method of [<code>BananoUtil</code>](#BananoUtil)  
+**Returns**: <code>string</code> - the message's hash.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| privateKey | <code>string</code> | the private key to use to sign. |
+| message | <code>string</code> | the utf-8 message to sign. |
+
+<a name="BananoUtil.verifyMessage"></a>
+
+### BananoUtil.verifyMessage(publicKey, message, signature) ⇒ <code>string</code>
+verifies a utf-8 message with public key.
+
+**Kind**: static method of [<code>BananoUtil</code>](#BananoUtil)  
+**Returns**: <code>string</code> - the message's hash.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| publicKey | <code>string</code> | the public key to use to sign. |
+| message | <code>string</code> | the utf-8 message to verify. |
+| signature | <code>string</code> | hex of signature. |
 
 <a name="BananoUtil.signHash"></a>
 

--- a/index.js
+++ b/index.js
@@ -724,6 +724,31 @@
   };
 
   /**
+   * signs a utf-8 message with private key.
+   *
+   * @memberof BananoUtil
+   * @param {string} privateKey the private key to use to sign.
+   * @param {string} message the utf-8 message to sign.
+   * @return {string} the message's hash.
+   */
+  const signMessage = (privateKey, message) => {
+    return bananoUtil.signMessage(privateKey, message);
+  };
+
+  /**
+   * verifies a utf-8 message with public key.
+   *
+   * @memberof BananoUtil
+   * @param {string} publicKey the public key to use to sign.
+   * @param {string} message the utf-8 message to verify.
+   * @param {string} signature hex of signature.
+   * @return {string} the message's hash.
+   */
+  const verifyMessage = (publicKey, message, signature) => {
+    return bananoUtil.verifyMessage(publicKey, message, signature);
+  }
+
+  /**
    * signs a hash.
    *
    * @memberof BananoUtil
@@ -1427,6 +1452,8 @@
       changeBananoRepresentativeForSeed;
     exports.changeNanoRepresentativeForSeed = changeNanoRepresentativeForSeed;
     exports.getSignature = getSignature;
+    exports.signMessage = signMessage;
+    exports.verifyMessage = verifyMessage;
     exports.signHash = signHash;
     exports.verify = verify;
     exports.getBytesFromHex = getBytesFromHex;

--- a/test/unit/message-signing-test.js
+++ b/test/unit/message-signing-test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+// libraries
+const chai = require('chai');
+
+// modules
+const expect = chai.expect;
+
+const bananoTest = require('./banano-test.json');
+
+const testUtil = require('../util/test-util.js');
+
+const expectedMessageSignature =
+  '66131ABCD9E65E59DE10C6A16AEC43424536CA66A0762B118DC3DFB9AC85C9661F5F757E8BFBF1EFFFE308C6D48E461279BBFFEE312745ADA31248E60DAE180A';
+
+const privateKey = bananoTest.privateKey;
+
+describe('message-sign', () => {
+  it('signature matches expected', () => {
+    const bananojs = testUtil.getBananojsWithMockApi();
+    const actualMessageSignature = bananojs.signMessage(privateKey, "test");
+    expect(actualMessageSignature).to.deep.equal(expectedMessageSignature);
+  });
+
+  it('signed message is verified', () => {
+    const bananojs = testUtil.getBananojsWithMockApi();
+    const signature = bananojs.signMessage(privateKey, "test");
+    const publicKey = window.bananocoinBananojs.getPublicKey(privateKey);
+    const signatureVerify = bananojs.verifyMessage(publicKey, "test", signature);
+    expect(signatureVerify).to.deep.equal(true);
+  });
+
+  it('invalid message is rejected', () => {
+    const bananojs = testUtil.getBananojsWithMockApi();
+    const signature = bananojs.signMessage(privateKey, "test");
+    const publicKey = window.bananocoinBananojs.getPublicKey(privateKey);
+    const signatureVerify = bananojs.verifyMessage(publicKey, "afjskfjsd7", signature);
+    expect(signatureVerify).to.deep.equal(false);
+  });
+
+  beforeEach(async () => {});
+
+  afterEach(async () => {
+    testUtil.deactivate();
+  });
+});


### PR DESCRIPTION
Adds two functions, one to sign any utf-8 message with a private key, and one to verify it, with the corresponding public key.

I've tested on my end, and it should work. Docs and whatnot are all updated also.
However I haven't got the slightest clue if I wrote the unit tests correctly, please check.