### PR TITLE
fix doc strings

### DIFF
--- a/dist/bananocoin-bananojs.js
+++ b/dist/bananocoin-bananojs.js
@@ -1,5 +1,5 @@
 //bananocoin-bananojs.js
-//version 2.10.0
+//version 2.10.1
 //license MIT
 /* eslint-disable */
 const require = (modname) => {
@@ -6365,7 +6365,7 @@ window.bananocoin.bananojs.https.request = (
    * @memberof BananoUtil
    * @param {string} privateKeyOrSigner the private key to use to sign.
    * @param {string} message the utf-8 message to sign.
-   * @return {string} the message's hash.
+   * @return {string} the message's signature.
    */
   const signMessage = (privateKeyOrSigner, message) => {
     return bananoUtil.signMessage(privateKeyOrSigner, message);
@@ -6413,7 +6413,7 @@ window.bananocoin.bananojs.https.request = (
    * @param {string} publicKey the public key to use to sign.
    * @param {string} message the utf-8 message to verify.
    * @param {string} signature hex of signature.
-   * @return {string} the message's hash.
+   * @return {boolean} whether the signature was verified.
    */
   const verifyMessage = (publicKey, message, signature) => {
     return bananoUtil.verifyMessage(publicKey, message, signature);

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -504,11 +504,11 @@ checks if a camo account is valid.
     * [.openBananoAccountFromSeed(seed, seedIx, representative, pendingBlockHash, pendingValueRaw)](#BananoUtil.openBananoAccountFromSeed) ⇒ <code>Promise.&lt;string&gt;</code>
     * [.openNanoAccountFromSeed(seed, seedIx, representative, pendingBlockHash, pendingValueRaw)](#BananoUtil.openNanoAccountFromSeed) ⇒ <code>Promise.&lt;string&gt;</code>
     * [.getBlockHash(block)](#BananoUtil.getBlockHash) ⇒ <code>string</code>
-    * [.signMessage(privateKeyOrSigner, message)](#BananoUtil.signMessage) ⇒ <code>string</code>
-    * [.hashMessageToBytes(message)](#BananoUtil.hashMessageToBytes) ⇒ <code>string</code>
-    * [.messageDummyBlockHashBytes(privateKey, message)](#BananoUtil.messageDummyBlockHashBytes) ⇒ <code>string</code>
+    * [.signMessage(privateKeyOrSigner, message)](#BananoUtil.signMessage) ⇒ <code>boolean</code>
+    * [.hashMessageToBytes(message)](#BananoUtil.hashMessageToBytes) ⇒ <code>Uint8Array</code>
+    * [.messageDummyBlockHashBytes(privateKey, message)](#BananoUtil.messageDummyBlockHashBytes) ⇒ <code>Uint8Array</code>
     * [.messageDummyBlock(privateKey, message)](#BananoUtil.messageDummyBlock) ⇒ <code>string</code>
-    * [.verifyMessage(publicKey, message, signature)](#BananoUtil.verifyMessage) ⇒ <code>string</code>
+    * [.verifyMessage(publicKey, message, signature)](#BananoUtil.verifyMessage) ⇒ <code>boolean</code>
     * [.signHash(privateKey, hash)](#BananoUtil.signHash) ⇒ <code>string</code>
     * [.verify(hash, signature, publicKey)](#BananoUtil.verify) ⇒ <code>string</code>
     * [.getSignature(privateKey, block)](#BananoUtil.getSignature) ⇒ <code>string</code>
@@ -761,11 +761,11 @@ Get the hash for a given block.
 
 <a name="BananoUtil.signMessage"></a>
 
-### BananoUtil.signMessage(privateKeyOrSigner, message) ⇒ <code>string</code>
+### BananoUtil.signMessage(privateKeyOrSigner, message) ⇒ <code>boolean</code>
 signs a dummy block with a hash of the utf-8 message using private key.
 
 **Kind**: static method of [<code>BananoUtil</code>](#BananoUtil)  
-**Returns**: <code>string</code> - the message's hash.  
+**Returns**: <code>boolean</code> - the message's signature.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -774,11 +774,11 @@ signs a dummy block with a hash of the utf-8 message using private key.
 
 <a name="BananoUtil.hashMessageToBytes"></a>
 
-### BananoUtil.hashMessageToBytes(message) ⇒ <code>string</code>
+### BananoUtil.hashMessageToBytes(message) ⇒ <code>Uint8Array</code>
 signs a utf-8 message with private key. Only used internally and for testing.
 
 **Kind**: static method of [<code>BananoUtil</code>](#BananoUtil)  
-**Returns**: <code>string</code> - the message's hash.  
+**Returns**: <code>Uint8Array</code> - hashed message's bytes.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -786,11 +786,11 @@ signs a utf-8 message with private key. Only used internally and for testing.
 
 <a name="BananoUtil.messageDummyBlockHashBytes"></a>
 
-### BananoUtil.messageDummyBlockHashBytes(privateKey, message) ⇒ <code>string</code>
+### BananoUtil.messageDummyBlockHashBytes(privateKey, message) ⇒ <code>Uint8Array</code>
 generates a dummy block hash that is used for message signing.
 
 **Kind**: static method of [<code>BananoUtil</code>](#BananoUtil)  
-**Returns**: <code>string</code> - the message's hash.  
+**Returns**: <code>Uint8Array</code> - hashed dummy block's bytes.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -812,11 +812,11 @@ generates a dummy block that is used for message signing.
 
 <a name="BananoUtil.verifyMessage"></a>
 
-### BananoUtil.verifyMessage(publicKey, message, signature) ⇒ <code>string</code>
+### BananoUtil.verifyMessage(publicKey, message, signature) ⇒ <code>boolean</code>
 verifies a utf-8 message with public key from a dummy block signature.
 
 **Kind**: static method of [<code>BananoUtil</code>](#BananoUtil)  
-**Returns**: <code>string</code> - the message's hash.  
+**Returns**: <code>boolean</code> - whether the signature was verified.  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/index.js
+++ b/index.js
@@ -729,7 +729,7 @@
    * @memberof BananoUtil
    * @param {string} privateKeyOrSigner the private key to use to sign.
    * @param {string} message the utf-8 message to sign.
-   * @return {string} the message's hash.
+   * @return {string} the message's signature.
    */
   const signMessage = (privateKeyOrSigner, message) => {
     return bananoUtil.signMessage(privateKeyOrSigner, message);
@@ -740,7 +740,7 @@
    *
    * @memberof BananoUtil
    * @param {string} message the utf-8 message to sign.
-   * @return {string} the message's hash.
+   * @return {Uint8Array} hashed message's bytes.
    */
   const hashMessageToBytes = (message) => {
     return bananoUtil.hashMessageToBytes(message);
@@ -752,7 +752,7 @@
    * @memberof BananoUtil
    * @param {string} privateKey the private key to use to sign.
    * @param {string} message the utf-8 message to sign.
-   * @return {string} the message's hash.
+   * @return {Uint8Array} hashed dummy block's bytes.
    */
   const messageDummyBlockHashBytes = (privateKey, message) => {
     return bananoUtil.messageDummyBlockHashBytes(privateKey, message);
@@ -777,7 +777,7 @@
    * @param {string} publicKey the public key to use to sign.
    * @param {string} message the utf-8 message to verify.
    * @param {string} signature hex of signature.
-   * @return {string} the message's hash.
+   * @return {boolean} whether the signature was verified.
    */
   const verifyMessage = (publicKey, message, signature) => {
     return bananoUtil.verifyMessage(publicKey, message, signature);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bananocoin/bananojs",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "module": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Several functions related to (block) message signing had incorrect return type doc strings.