### PR TITLE
add setting arbitrary headers

### DIFF
--- a/app/scripts/bananode-api.js
+++ b/app/scripts/bananode-api.js
@@ -15,18 +15,29 @@
 
   const LOG_GET_GENERATED_WORK = false;
 
-  let auth;
+  let auth, arbitraryHeaders;
 
   /**
    * Sets an authorization string (http 'Authorization' header), useful if node requires api key.
    *
    * @memberof BananodeApi
-   * @param {string} authString api key as a string\
+   * @param {string} authString api key as a string
    * @return {undefined} returns nothing.
    */
   const setAuth = (authString) => {
     auth = authString;
   };
+
+  /**
+   * Sets arbitrary headers
+   *
+   * @memberof BananodeApi
+   * @param {Object.<string, string>} headers key-value pair object of header names (key) to header values (value), trying to specify Content-Type and Content-Length headers will not work
+   * @return {undefined} returns nothing.
+   */
+  const setHeaders = (arbitraryHeaders) => {
+    arbitraryHeaders = arbitraryHeaders;
+  }
 
   const delay = (time) => {
     // console.log('delay', 'time', time);
@@ -61,6 +72,7 @@
         path: apiUrl.pathname,
         port: apiUrl.port,
         headers: {
+          ...arbitraryHeaders,
           'Content-Type': 'application/json',
           'Content-Length': body.length,
         },
@@ -626,6 +638,7 @@
     exports.log = console.log;
     exports.trace = console.trace;
     exports.setAuth = setAuth;
+    exports.setHeaders = setHeaders;
 
     return exports;
   })();

--- a/dist/bananocoin-bananojs.js
+++ b/dist/bananocoin-bananojs.js
@@ -2116,18 +2116,29 @@ window.bananocoin.bananojs.https.request = (
 
   const LOG_GET_GENERATED_WORK = false;
 
-  let auth;
+  let auth, arbitraryHeaders;
 
   /**
    * Sets an authorization string (http 'Authorization' header), useful if node requires api key.
    *
    * @memberof BananodeApi
-   * @param {string} authString api key as a string\
+   * @param {string} authString api key as a string
    * @return {undefined} returns nothing.
    */
   const setAuth = (authString) => {
     auth = authString;
   };
+
+  /**
+   * Sets arbitrary headers
+   *
+   * @memberof BananodeApi
+   * @param {Object.<string, string>} headers key-value pair object of header names (key) to header values (value), trying to specify Content-Type and Content-Length headers will not work
+   * @return {undefined} returns nothing.
+   */
+  const setHeaders = (arbitraryHeaders) => {
+    arbitraryHeaders = arbitraryHeaders;
+  }
 
   const delay = (time) => {
     // console.log('delay', 'time', time);
@@ -2162,6 +2173,7 @@ window.bananocoin.bananojs.https.request = (
         path: apiUrl.pathname,
         port: apiUrl.port,
         headers: {
+          ...arbitraryHeaders,
           'Content-Type': 'application/json',
           'Content-Length': body.length,
         },
@@ -2727,6 +2739,7 @@ window.bananocoin.bananojs.https.request = (
     exports.log = console.log;
     exports.trace = console.trace;
     exports.setAuth = setAuth;
+    exports.setHeaders = setHeaders;
 
     return exports;
   })();

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -35,6 +35,7 @@
     * [.BANANO_PREFIX](#Main.BANANO_PREFIX) : <code>string</code>
     * [.setBananodeApi(_bananodeApi)](#Main.setBananodeApi) ⇒ <code>undefined</code>
     * [.setAuth(auth)](#Main.setAuth) ⇒ <code>undefined</code>
+    * [.setHeaders(headers)](#BananodeApi.setHeaders) ⇒ <code>undefined</code>
     * [.setBananodeApiProxy(proxy)](#Main.setBananodeApiProxy) ⇒ <code>undefined</code>
     * [.getBananodeApiProxy()](#Main.getBananodeApiProxy) ⇒ <code>Object</code>
     * [.setBananodeApiUrl(url)](#Main.setBananodeApiUrl) ⇒ <code>undefined</code>
@@ -1361,7 +1362,19 @@ Sets an authorization string (http 'Authorization' header), useful if node requi
 
 | Param | Type | Description |
 | --- | --- | --- |
-| authString | <code>string</code> | api key as a string\ |
+| authString | <code>string</code> | api key as a string |
+
+<a name="BananodeApi.setHeaders"></a>
+
+### BananodeApi.setHeaders(headers) ⇒ <code>undefined</code>
+Sets arbitrary headers
+
+**Kind**: static method of [<code>BananodeApi</code>](#BananodeApi)  
+**Returns**: <code>undefined</code> - returns nothing.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| headers | <code>Object.&lt;string, string&gt;</code> | key-value pair object of header names (key) to header values (value), trying to specify Content-Type and Content-Length headers will not work |
 
 <a name="BananoParts"></a>
 


### PR DESCRIPTION
Should add ability to send arbitrary headers to the RPC, not just `Authorization`.

I ran `npm run build` and semi-manually added to the docs, but am unsure how to add to `index.js`, so I didn't do anything there.

[Spread operator (...) in object literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#browser_compatibility) is supported in all browsers and Node.js since v8.3.0.